### PR TITLE
Fixed the methods AddSecurityMember and UpdateSecurityMembers in the FoldersManager

### DIFF
--- a/VVRestApi/VVRestApi/VVRestApi.csproj
+++ b/VVRestApi/VVRestApi/VVRestApi.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>VVRestApi</PackageId>
-    <Version>5.0.5</Version>
+    <Version>5.0.6</Version>
     <AssemblyVersion>5.0.5.0</AssemblyVersion>
     <Product>VisualVault REST API for .NET</Product>
     <Copyright>Copyright ©  2019</Copyright>
     <Description>VisualVault REST API for .NET</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>VisualVault</Company>
-    <PackageReleaseNotes>Added method to UsersManager to get user's groups</PackageReleaseNotes>
+    <PackageReleaseNotes>Resolved bug that prevented the AddSecurityMember and UpdateSecurityMembers folder methods from working properly.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/VisualVault/VisualVault.Net.RestClient</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageLicenseExpression></PackageLicenseExpression>

--- a/VVRestApi/VVRestApi/Vault/Library/FoldersManager.cs
+++ b/VVRestApi/VVRestApi/Vault/Library/FoldersManager.cs
@@ -368,7 +368,7 @@ namespace VVRestApi.Vault.Library
             postData.securityActions = securityActionList;
             postData.cascadeSecurityChanges = cascadeSecurityChanges;
 
-            var result = HttpHelper.Put(GlobalConfiguration.Routes.FoldersIdSecurityMembers, "", GetUrlParts(), this.ApiTokens, postData, folderId);
+            var result = HttpHelper.Put(GlobalConfiguration.Routes.FoldersIdSecurityMembers, "", GetUrlParts(), this.ApiTokens, this.ClientSecrets, postData, folderId);
             var data = result.GetValue("data") as JObject;
             if (data != null)
             {
@@ -387,7 +387,7 @@ namespace VVRestApi.Vault.Library
             postData.securityRole = securityRole;
             postData.cascadeSecurityChanges = cascadeSecurityChanges;
 
-            var result = HttpHelper.Put(GlobalConfiguration.Routes.FoldersIdSecurityMembersId, "", GetUrlParts(), this.ApiTokens, postData, folderId, memberId);
+            var result = HttpHelper.Put(GlobalConfiguration.Routes.FoldersIdSecurityMembersId, "", GetUrlParts(), this.ApiTokens, this.ClientSecrets, postData, folderId, memberId);
             var data = result.GetValue("data") as JObject;
             if (data != null)
             {


### PR DESCRIPTION
Fixed the methods AddSecurityMember and UpdateSecurityMembers in the FoldersManager so they work. Before this fix, using these methods would throw an exception due to the calls to the httphelper put method not including the client secrets.