### PR TITLE
Added support for UpdateDocumentMetadata and Core test

### DIFF
--- a/VVRestApi/VVRestApi/VVRestApi.csproj
+++ b/VVRestApi/VVRestApi/VVRestApi.csproj
@@ -3,18 +3,18 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>VVRestApi</PackageId>
-    <Version>5.0.11</Version>
-    <AssemblyVersion>5.0.11.0</AssemblyVersion>
+    <Version>5.0.12</Version>
+    <AssemblyVersion>5.0.12.0</AssemblyVersion>
     <Product>VisualVault REST API for .NET</Product>
     <Copyright>Copyright ©  2021</Copyright>
     <Description>VisualVault REST API for .NET</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>VisualVault</Company>
-    <PackageReleaseNotes>Added Copy Document method</PackageReleaseNotes>
+    <PackageReleaseNotes>Added Update Document Metadata Method</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/VisualVault/VisualVault.Net.RestClient</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageLicenseExpression></PackageLicenseExpression>
-    <FileVersion>5.0.11.0</FileVersion>
+    <FileVersion>5.0.12.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VVRestApi/VVRestApi/Vault/Library/DocumentsManager.cs
+++ b/VVRestApi/VVRestApi/Vault/Library/DocumentsManager.cs
@@ -92,7 +92,7 @@ namespace VVRestApi.Vault.Library
                 var jobjectString = JsonConvert.SerializeObject(jobject);
 
                 postData.indexFields =jobjectString;
-            }
+            }            
 
             return HttpHelper.Post<Document>(GlobalConfiguration.Routes.Documents, string.Empty, GetUrlParts(), this.ClientSecrets, this.ApiTokens, postData);
         }
@@ -157,7 +157,7 @@ namespace VVRestApi.Vault.Library
             }
             var jobjectString = JsonConvert.SerializeObject(jobject);
             postData.indexFields = jobjectString;
-
+            
             return HttpHelper.Post<Document>(GlobalConfiguration.Routes.Documents, string.Empty, GetUrlParts(), this.ClientSecrets, this.ApiTokens, postData);
         }
 
@@ -171,7 +171,7 @@ namespace VVRestApi.Vault.Library
             var success = false;
 
             var queryString = "purge=" + purgeDocument;
-
+             
             var httpResult = HttpHelper.DeleteReturnMeta(GlobalConfiguration.Routes.DocumentsId, queryString, GetUrlParts(), this.ApiTokens, this.ClientSecrets, dhId);
             if (httpResult != null && httpResult.IsAffirmativeStatus())
             {
@@ -187,7 +187,7 @@ namespace VVRestApi.Vault.Library
             {
                 options.Fields = UrlEncode(options.Fields);
             }
-
+            
             return HttpHelper.GetListResult<DocumentIndexField>(GlobalConfiguration.Routes.DocumentsIndexFields, "", options, GetUrlParts(), this.ClientSecrets, this.ApiTokens, dlId);
         }
 
@@ -375,7 +375,7 @@ namespace VVRestApi.Vault.Library
             }
 
             dynamic postData = new JObject();
-            postData.checkInDocumentState = (int)documentState;
+            postData.checkInDocumentState = (int)documentState;            
 
             return HttpHelper.Put(GlobalConfiguration.Routes.DocumentsUpdateReleaseState, "", GetUrlParts(), this.ApiTokens, this.ClientSecrets, postData, dlId, dhId);
         }

--- a/VVRestApi/VVRestApi/Vault/Library/DocumentsManager.cs
+++ b/VVRestApi/VVRestApi/Vault/Library/DocumentsManager.cs
@@ -92,7 +92,7 @@ namespace VVRestApi.Vault.Library
                 var jobjectString = JsonConvert.SerializeObject(jobject);
 
                 postData.indexFields =jobjectString;
-            }            
+            }
 
             return HttpHelper.Post<Document>(GlobalConfiguration.Routes.Documents, string.Empty, GetUrlParts(), this.ClientSecrets, this.ApiTokens, postData);
         }
@@ -157,7 +157,7 @@ namespace VVRestApi.Vault.Library
             }
             var jobjectString = JsonConvert.SerializeObject(jobject);
             postData.indexFields = jobjectString;
-            
+
             return HttpHelper.Post<Document>(GlobalConfiguration.Routes.Documents, string.Empty, GetUrlParts(), this.ClientSecrets, this.ApiTokens, postData);
         }
 
@@ -171,7 +171,7 @@ namespace VVRestApi.Vault.Library
             var success = false;
 
             var queryString = "purge=" + purgeDocument;
-             
+
             var httpResult = HttpHelper.DeleteReturnMeta(GlobalConfiguration.Routes.DocumentsId, queryString, GetUrlParts(), this.ApiTokens, this.ClientSecrets, dhId);
             if (httpResult != null && httpResult.IsAffirmativeStatus())
             {
@@ -187,7 +187,7 @@ namespace VVRestApi.Vault.Library
             {
                 options.Fields = UrlEncode(options.Fields);
             }
-            
+
             return HttpHelper.GetListResult<DocumentIndexField>(GlobalConfiguration.Routes.DocumentsIndexFields, "", options, GetUrlParts(), this.ClientSecrets, this.ApiTokens, dlId);
         }
 
@@ -375,7 +375,7 @@ namespace VVRestApi.Vault.Library
             }
 
             dynamic postData = new JObject();
-            postData.checkInDocumentState = (int)documentState;            
+            postData.checkInDocumentState = (int)documentState;
 
             return HttpHelper.Put(GlobalConfiguration.Routes.DocumentsUpdateReleaseState, "", GetUrlParts(), this.ApiTokens, this.ClientSecrets, postData, dlId, dhId);
         }
@@ -391,6 +391,44 @@ namespace VVRestApi.Vault.Library
             postData.checkIn = (int)checkInStatus;
 
             return HttpHelper.Put(GlobalConfiguration.Routes.DocumentsUpdateCheckInStatus, "", GetUrlParts(), this.ApiTokens, this.ClientSecrets, postData, dlId);
+        }
+
+        /// <summary>
+        /// Updates a the metadata fields of a document's latest revision. Null parameters will be ignored in update.
+        /// </summary>
+        /// <param name="dlId">DocumentId</param>
+        /// <param name="newName"></param>
+        /// <param name="newRevision"></param>
+        /// <param name="newDescription"></param>
+        /// <param name="newKeywords"></param>
+        /// <param name="newComments"></param>
+        /// <param name="archiveType"></param>
+        /// <param name="documentState"></param>
+        /// <returns>Document with updated metadata</returns>
+        public Document UpdateDocumentMetadata(Guid dlId, string newName = null, string newRevision = null, string newDescription = null, string newKeywords = null, string newComments = null, ArchiveType? archiveType = null, DocumentState? documentState = null)
+        {
+            if (dlId.Equals(Guid.Empty))
+            {
+                throw new ArgumentException("Document Id is required but was an empty Guid", "dlId");
+            }
+
+            dynamic putData = new JObject();
+            if (newName != null)
+                putData.name = newName;
+            if (newRevision != null)
+                putData.displayRev = newRevision;
+            if (newDescription != null)
+                putData.description = newDescription;
+            if (newKeywords != null)
+                putData.keywords = newKeywords;
+            if (newComments != null)
+                putData.comments = newComments;
+            if (archiveType != null)
+                putData.archive = (int)archiveType;
+            if (documentState != null)
+                putData.state = (int)documentState;
+
+            return HttpHelper.Put<Document>(GlobalConfiguration.Routes.DocumentsId, "", GetUrlParts(), this.ClientSecrets, this.ApiTokens, putData, dlId);
         }
     }
 }

--- a/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests.cs
+++ b/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests.cs
@@ -1356,6 +1356,19 @@ namespace VVRestApiTests.Core.Tests
             }
         }
 
+        [Test]
+        public void UpdateDocumentMetadata()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+
+            var document = vaultApi.Documents.UpdateDocumentMetadata(new Guid(), "1234", "displayRevValue", "descriptionValue", "keywordsValue", "commentsValue", ArchiveType.Active, DocumentState.Released);
+
+            Assert.IsNotNull(document);
+        }
+
 
         #endregion
 


### PR DESCRIPTION
This new method is to take advantage of the new PUT endpoint for '~/documents/{id}'.