### PR TITLE
Add support for paging, sorting and query parameters to custom query result methods

### DIFF
--- a/VVRestApi/VVRestApi/Common/Messaging/HttpHelper.cs
+++ b/VVRestApi/VVRestApi/Common/Messaging/HttpHelper.cs
@@ -1960,12 +1960,12 @@ namespace VVRestApi.Common.Messaging
                         result.Meta = resultData["meta"].ToObject<ApiMetaData>();
 
                         //Pull all the paged data information
-                        result.First = paginationToken["first"].Value<string>();
-                        result.Last = paginationToken["last"].Value<string>();
-                        result.Limit = paginationToken["limit"].Value<int>();
-                        result.Next = paginationToken["next"].Value<string>();
-                        result.Previous = paginationToken["previous"].Value<string>();
-                        result.TotalRecords = paginationToken["totalRecords"].Value<int>();
+                        result.First = paginationToken["first"] == null ? string.Empty : paginationToken["first"].Value<string>();
+                        result.Last = paginationToken["last"] == null ? string.Empty : paginationToken["last"].Value<string>();
+                        result.Limit = paginationToken["limit"] == null ? 0 : paginationToken["limit"].Value<int>();
+                        result.Next = paginationToken["next"] == null ? string.Empty : paginationToken["next"].Value<string>();
+                        result.Previous = paginationToken["previous"] == null ? string.Empty : paginationToken["previous"].Value<string>();
+                        result.TotalRecords = paginationToken["totalRecords"] == null ? 0 : paginationToken["totalRecords"].Value<int>();
                     }
 
 

--- a/VVRestApi/VVRestApi/VVRestApi.csproj
+++ b/VVRestApi/VVRestApi/VVRestApi.csproj
@@ -3,18 +3,18 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>VVRestApi</PackageId>
-    <Version>5.0.16</Version>
-    <AssemblyVersion>5.0.16.0</AssemblyVersion>
+    <Version>5.0.17</Version>
+    <AssemblyVersion>5.0.17.0</AssemblyVersion>
     <Product>VisualVault REST API for .NET</Product>
     <Copyright>Copyright ©  2021</Copyright>
     <Description>VisualVault REST API for .NET</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>VisualVault</Company>
-    <PackageReleaseNotes>Added Get Forms Related to Forms method</PackageReleaseNotes>
+    <PackageReleaseNotes>Added GetCustomQueryPagedResults method to CustomQueryManager and also added sort and query parameter arguments to all GetCustomQueryResults and GetCustomQueryPagedResults methods.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/VisualVault/VisualVault.Net.RestClient</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageLicenseExpression></PackageLicenseExpression>
-    <FileVersion>5.0.16.0</FileVersion>
+    <FileVersion>5.0.17.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VVRestApi/VVRestApi/Vault/CustomQueries/CustomQueryManager.cs
+++ b/VVRestApi/VVRestApi/Vault/CustomQueries/CustomQueryManager.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using VVRestApi.Common;
 using VVRestApi.Common.Messaging;
 using VVRestApi.Vault.Users;
+using System.Collections.Generic;
 
 namespace VVRestApi.Vault.CustomQueries
 {
@@ -18,19 +19,45 @@ namespace VVRestApi.Vault.CustomQueries
         /// <param name="queryName"></param>
         /// <param name="options"></param>
         /// <param name="filter"></param>
+        /// <param name="sortBy"></param>
+        /// <param name="sortDirection"></param>
+        /// <param name="queryParameters"></param>
         /// <returns></returns>
-        public JArray GetCustomQueryResults(string queryName, RequestOptions options = null, string filter = null)
+        public JArray GetCustomQueryResults(string queryName, RequestOptions options = null, string filter = null, string sortBy = null, string sortDirection = null, Dictionary<string,string> queryParameters = null)
         {
             if (options != null && !string.IsNullOrWhiteSpace(options.Fields))
             {
                 options.Fields = UrlEncode(options.Fields);
             }
-            var queryString = string.Format("queryName={0}", UrlEncode(queryName));
+            var queryString = "";
 
+            List<string> queryStrings = new List<string>();
+            queryStrings.Add($"queryName={UrlEncode(queryName)}");
             if (filter != null)
             {
-                queryString += $"&filter={UrlEncode(filter)}";
+                queryStrings.Add($"filter={UrlEncode(filter)}");
             }
+            if (sortBy != null)
+            {
+                queryStrings.Add($"sort={UrlEncode(sortBy)}");
+            }
+            if (sortDirection != null)
+            {
+                queryStrings.Add($"sortDir={UrlEncode(sortDirection)}");
+            }
+            if (queryParameters != null && queryParameters.Count > 0)
+            {
+                JArray queryParametersJArray = new JArray();
+                foreach (var queryParam in queryParameters)
+                {
+                    JObject queryParamJObject = new JObject();
+                    queryParamJObject["parameterName"] = queryParam.Key;
+                    queryParamJObject["value"] = queryParam.Value;
+                    queryParametersJArray.Add(queryParamJObject);
+                }
+                queryStrings.Add($"params={UrlEncode(queryParametersJArray.ToString(Newtonsoft.Json.Formatting.None))}");
+            }
+            queryString = String.Join("&", queryStrings);
 
             var results = HttpHelper.Get(GlobalConfiguration.Routes.CustomQuery, queryString, options, GetUrlParts(), this.ApiTokens, this.ClientSecrets);
             var data = results.Value<JArray>("data");
@@ -42,9 +69,12 @@ namespace VVRestApi.Vault.CustomQueries
         /// </summary>
         /// <param name="queryId"></param>
         /// <param name="options"></param>
-        /// /// <param name="filter"></param>
+        /// <param name="filter"></param>
+        /// <param name="sortBy"></param>
+        /// <param name="sortDirection"></param>
+        /// <param name="queryParameters"></param>
         /// <returns></returns>
-        public dynamic GetCustomQueryResults(Guid queryId, RequestOptions options = null, string filter = null)
+        public dynamic GetCustomQueryResults(Guid queryId, RequestOptions options = null, string filter = null, string sortBy = null, string sortDirection = null, Dictionary<string, string> queryParameters = null)
         {
             if (options != null && !string.IsNullOrWhiteSpace(options.Fields))
             {
@@ -52,14 +82,135 @@ namespace VVRestApi.Vault.CustomQueries
             }
 
             var queryString = "";
+            List<string> queryStrings = new List<string>();
             if (filter != null)
             {
-                queryString += $"filter={UrlEncode(filter)}";
+                queryStrings.Add($"filter={UrlEncode(filter)}");
             }
+            if (sortBy != null)
+            {
+                queryStrings.Add($"sort={UrlEncode(sortBy)}");
+            }
+            if (sortDirection != null)
+            {
+                queryStrings.Add($"sortDir={UrlEncode(sortDirection)}");
+            }
+            if (queryParameters != null && queryParameters.Count > 0)
+            {
+                JArray queryParametersJArray = new JArray();
+                foreach (var queryParam in queryParameters)
+                {
+                    JObject queryParamJObject = new JObject();
+                    queryParamJObject["parameterName"] = queryParam.Key;
+                    queryParamJObject["value"] = queryParam.Value;
+                    queryParametersJArray.Add(queryParamJObject);
+                }
+                queryStrings.Add($"params={UrlEncode(queryParametersJArray.ToString(Newtonsoft.Json.Formatting.None))}");
+            }
+            queryString = String.Join("&", queryStrings);
 
             var results = HttpHelper.Get(GlobalConfiguration.Routes.CustomQueryId, queryString, options, GetUrlParts(), this.ApiTokens, this.ClientSecrets, queryId);
             var data = results.Value<JArray>("data");
             return data;
+        }
+
+        /// <summary>
+        /// returns the result of a saved query as a <see cref="Page{CustomQueryResult}"/> object
+        /// </summary>
+        /// <param name="queryName"></param>
+        /// <param name="options"></param>
+        /// <param name="filter"></param>
+        /// <param name="sortBy"></param>
+        /// <param name="sortDirection"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public Page<CustomQueryResult> GetCustomQueryPagedResults(string queryName, RequestOptions options = null, string filter = null, string sortBy = null, string sortDirection = null, Dictionary<string, string> queryParameters = null)
+        {
+            if (options != null && !string.IsNullOrWhiteSpace(options.Fields))
+            {
+                options.Fields = UrlEncode(options.Fields);
+            }
+
+            var queryString = "";
+            List<string> queryStrings = new List<string>();
+            queryStrings.Add($"queryName={UrlEncode(queryName)}");
+            if (filter != null)
+            {
+                queryStrings.Add($"filter={UrlEncode(filter)}");
+            }
+            if (sortBy != null)
+            {
+                queryStrings.Add($"sort={UrlEncode(sortBy)}");
+            }
+            if (sortDirection != null)
+            {
+                queryStrings.Add($"sortDir={UrlEncode(sortDirection)}");
+            }
+            if (queryParameters != null && queryParameters.Count > 0)
+            {
+                JArray queryParametersJArray = new JArray();
+                foreach (var queryParam in queryParameters)
+                {
+                    JObject queryParamJObject = new JObject();
+                    queryParamJObject["parameterName"] = queryParam.Key;
+                    queryParamJObject["value"] = queryParam.Value;
+                    queryParametersJArray.Add(queryParamJObject);
+                }
+                queryStrings.Add($"params={UrlEncode(queryParametersJArray.ToString(Newtonsoft.Json.Formatting.None))}");
+            }
+            queryString = String.Join("&", queryStrings);
+
+            var results = HttpHelper.GetPagedResult<CustomQueryResult>(GlobalConfiguration.Routes.CustomQuery, queryString, options, GetUrlParts(), this.ClientSecrets, this.ApiTokens);
+            return results;
+        }
+
+        /// <summary>
+        /// returns the result of a saved query as a <see cref="Page{CustomQueryResult}"/> object
+        /// </summary>
+        /// <param name="queryId"></param>
+        /// <param name="options"></param>
+        /// <param name="filter"></param>
+        /// <param name="sortBy"></param>
+        /// <param name="sortDirection"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public Page<CustomQueryResult> GetCustomQueryPagedResults(Guid queryId, RequestOptions options = null, string filter = null, string sortBy = null, string sortDirection = null, Dictionary<string, string> queryParameters = null)
+        {
+            if (options != null && !string.IsNullOrWhiteSpace(options.Fields))
+            {
+                options.Fields = UrlEncode(options.Fields);
+            }
+
+            var queryString = "";
+            List<string> queryStrings = new List<string>();
+            if (filter != null)
+            {
+                queryStrings.Add($"filter={UrlEncode(filter)}");
+            }
+            if (sortBy != null)
+            {
+                queryStrings.Add($"sort={UrlEncode(sortBy)}");
+            }
+            if (sortDirection != null)
+            {
+                queryStrings.Add($"sortDir={UrlEncode(sortDirection)}");
+            }
+            if(queryParameters != null && queryParameters.Count > 0)
+            {
+                JArray queryParametersJArray = new JArray();
+                foreach(var queryParam in queryParameters)
+                {
+                    JObject queryParamJObject = new JObject();
+                    queryParamJObject["parameterName"] = queryParam.Key;
+                    queryParamJObject["value"] = queryParam.Value;
+                    queryParametersJArray.Add(queryParamJObject);
+                }
+                queryStrings.Add($"params={UrlEncode(queryParametersJArray.ToString(Newtonsoft.Json.Formatting.None))}");
+            }
+            queryString = String.Join("&", queryStrings);
+
+            var results = HttpHelper.GetPagedResult<CustomQueryResult>(GlobalConfiguration.Routes.CustomQueryId, queryString, options, GetUrlParts(), this.ClientSecrets, this.ApiTokens, queryId);
+            return results;
         }
 
     }

--- a/VVRestApi/VVRestApi/Vault/CustomQueries/CustomQueryResult.cs
+++ b/VVRestApi/VVRestApi/Vault/CustomQueries/CustomQueryResult.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VVRestApi.Common;
+using Newtonsoft.Json.Linq;
+
+namespace VVRestApi.Vault.CustomQueries
+{
+    public class CustomQueryResult : RestObject
+    {
+        public List<KeyValuePair<string, string>> Data { get; set; }
+
+        internal override void PopulateData(JToken data)
+        {
+            Data = new List<KeyValuePair<string, string>>();
+
+            var jobject = data as JObject;
+            if (jobject != null)
+            {
+                foreach (var dataProperty in jobject)
+                {
+                    Data.Add(new KeyValuePair<string, string>(dataProperty.Key, dataProperty.Value.ToString()));
+                }
+            }
+        }
+    }
+}

--- a/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests.cs
+++ b/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests.cs
@@ -2138,6 +2138,445 @@ namespace VVRestApiTests.Core.Tests
             var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId);
         }
 
+        [Test]
+        public void GetCustomQueryByQueryNameWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, filter);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Count, 1);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, filter);
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Count, 1);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNameWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results[0]["uspKey"].ToString();
+            var lastValue = results[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = ((JArray)results)[0]["uspKey"].ToString();
+            var lastValue = ((JArray)results)[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNameWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results[0]["uspKey"].ToString();
+            var lastValue = results[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = ((JArray)results)[0]["uspKey"].ToString();
+            var lastValue = ((JArray)results)[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePaged()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPaged()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+
+        [Test]
+        public void GetCustomQueryByQueryNamePagedWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdPagedWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNamePagedWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdPagedWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePagedWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, filter);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPagedWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, filter);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePagedWithQuery()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            options.Query = "ususerid eq 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPagedWithQuery()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            options.Query = "ususerid eq 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNameWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, null, null, null, queryParameters);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Count, 0);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, null, null, null, queryParameters);
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Count, 0);
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePagedWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, null, null, null, queryParameters);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPagedWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, null, null, null, queryParameters);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
         #endregion
 
         #region Tests

--- a/VVRestApi/VVRestApiTests/Tests/RestApiTests.cs
+++ b/VVRestApi/VVRestApiTests/Tests/RestApiTests.cs
@@ -2103,6 +2103,445 @@ namespace VVRestApiTests.Tests
             var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId);
         }
 
+        [Test]
+        public void GetCustomQueryByQueryNameWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, filter);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Count, 1);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, filter);
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Count, 1);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNameWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results[0]["uspKey"].ToString();
+            var lastValue = results[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = ((JArray)results)[0]["uspKey"].ToString();
+            var lastValue = ((JArray)results)[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNameWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results[0]["uspKey"].ToString();
+            var lastValue = results[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = ((JArray)results)[0]["uspKey"].ToString();
+            var lastValue = ((JArray)results)[1]["uspKey"].ToString();
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePaged()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPaged()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options);
+            
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+
+        [Test]
+        public void GetCustomQueryByQueryNamePagedWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdPagedWithSortAsc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "asc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(lastValue), Int32.Parse(firstValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNamePagedWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, null, sortBy, sortDirection);
+
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdPagedWithSortDesc()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            string sortBy = "uspkey";
+            string sortDirection = "desc";
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, null, sortBy, sortDirection);
+            Assert.IsNotNull(results);
+            var firstValue = results.Items.ElementAt(0).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            var lastValue = results.Items.ElementAt(1).Data.Find(x => x.Key.ToLower() == "uspkey").Value;
+            Assert.Greater(Int32.Parse(firstValue), Int32.Parse(lastValue));
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePagedWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, filter);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPagedWithFilter()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            string filter = "ususerid = 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, filter);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePagedWithQuery()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            options.Query = "ususerid eq 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPagedWithQuery()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "users";
+            var queryId = new Guid("83f38ad8-53a4-ea11-ae3d-5048494f4e43");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            options.Query = "ususerid eq 'vault.config'";
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options);
+
+            Assert.IsNotNull(results);
+            Assert.AreEqual(results.Items.Count, 1);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryNameWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryName, null, null, null, null, queryParameters);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Count, 0);
+        }
+
+        [Test]
+        public void GetCustomQueryByQueryIdWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryResults(queryId, null, null, null, null, queryParameters);
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Count, 0);
+        }
+
+        [Test]
+        public void GetCustomQueryByNamePagedWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryName, options, null, null, null, queryParameters);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
+        [Test]
+        public void GetCustomQueryByIdPagedWithParams()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            var queryName = "usersparams";
+            var queryId = new Guid("3ff21e68-263c-ec11-aecd-34298f90235b");
+
+            RequestOptions options = new RequestOptions();
+            options.Take = 10;
+            options.Skip = 0;
+
+            Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+            queryParameters.Add("Param", "vault");
+
+            var results = vaultApi.CustomQueryManager.GetCustomQueryPagedResults(queryId, options, null, null, null, queryParameters);
+
+            Assert.IsNotNull(results);
+            Assert.Greater(results.Items.Count, 0);
+            Assert.LessOrEqual(results.Items.Count, 10);
+        }
+
         #endregion
 
         #region Tests


### PR DESCRIPTION
Added GetCustomQueryPagedResults methods to CustomQueryManager to fully support paging for custom queries and also added sort and query parameter arguments to all GetCustomQueryResults and GetCustomQueryPagedResults methods in CustomQueryManager.