### PR TITLE
Update RequestObject querystring parser to handle multiple '=' characters in a single part

### DIFF
--- a/VVRestApi/VVRestApi/Common/RequestOptions.cs
+++ b/VVRestApi/VVRestApi/Common/RequestOptions.cs
@@ -301,10 +301,15 @@ namespace VVRestApi.Common
                 }, StringSplitOptions.RemoveEmptyEntries);
 
                 var key = parts[0].Trim();
-                if (parts.Length == 2)
+                if (parts.Length > 1)
                 {
                     //var value = HttpUtility.UrlDecode(parts[1]);
-                    var value = parts[1];
+                    var value = parts[1].Trim();
+                    // if there are other '=' characters in the set, just include them
+                    for (var i = 2; i < parts.Length; i++) 
+                    {
+                        value += $" = {parts[i].Trim()}";
+                    }
 
                     queryDict[key] = (value ?? "").Trim();
                 }

--- a/VVRestApi/VVRestApi/VVRestApi.csproj
+++ b/VVRestApi/VVRestApi/VVRestApi.csproj
@@ -3,18 +3,18 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>VVRestApi</PackageId>
-    <Version>5.0.22</Version>
-    <AssemblyVersion>5.0.22.0</AssemblyVersion>
+    <Version>5.0.23</Version>
+    <AssemblyVersion>5.0.23.0</AssemblyVersion>
     <Product>VisualVault REST API for .NET</Product>
     <Copyright>Copyright ©  2022</Copyright>
     <Description>VisualVault REST API for .NET</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>VisualVault</Company>
-    <PackageReleaseNotes>Added CreateDocumentWithFile method in the DocumentsManager</PackageReleaseNotes>
+    <PackageReleaseNotes>Update RequestObject querystring parser to handle multiple '=' characters in a single part</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/VisualVault/VisualVault.Net.RestClient</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageLicenseExpression></PackageLicenseExpression>
-    <FileVersion>5.0.22.0</FileVersion>
+    <FileVersion>5.0.23.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests.cs
+++ b/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests.cs
@@ -2589,6 +2589,24 @@ namespace VVRestApiTests.Core.Tests
 
             var request = options.GetQueryString("q=userid eq 'vault.config'&stuff=things");
             Assert.IsNotEmpty(request);
+            Assert.IsTrue(request.Contains("q=(userid eq 'vault.config') AND (name eq 'world' AND id eq 'whatever')"));
+        }
+
+        [Test]
+        public void RequestOptionsGiveBackGoodQuery()
+        {
+            var reqOpts = new VVRestApi.Common.RequestOptions
+            {
+                Fields = @"VV Provider ID, CPR Number, EI Last Name, EI First Name, ADSA Client ID, ESIT Client ID, VisualVault Individual ID, Authorization Number DDA, Authorization Number ESIT, Authorization Number School Dist, Fund Source, RAC Code, CPR Number,
+             Date of Record, Service Year Month, Program Type, Service Type, Status",
+                Query = $"[VV Provider ID] eq 'pro_001' AND [CPR Number] = 'WrongNumber'",
+                Take = 2000
+            };
+
+            
+            var queryString = reqOpts.GetQueryString("");
+
+            Assert.IsTrue(queryString.Contains("q=[VV Provider ID] eq 'pro_001' AND [CPR Number] = 'WrongNumber'"));
         }
 
         [Test]


### PR DESCRIPTION
Related to VV story 25097