### PR TITLE
28619 | Extended Site CreateUser Field Support + Created Test Case

### DIFF
--- a/VVRestApi/VVRestApi/VVRestApi.csproj
+++ b/VVRestApi/VVRestApi/VVRestApi.csproj
@@ -3,18 +3,18 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>VVRestApi</PackageId>
-    <Version>5.2.5</Version>
-    <AssemblyVersion>5.2.5.0</AssemblyVersion>
+    <Version>5.2.6</Version>
+    <AssemblyVersion>5.2.6.0</AssemblyVersion>
     <Product>VisualVault REST API for .NET</Product>
     <Copyright>Copyright ©  2022</Copyright>
     <Description>VisualVault REST API for .NET</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>VisualVault</Company>
-    <PackageReleaseNotes>Fix mapping for DocApi index fields</PackageReleaseNotes>
+    <PackageReleaseNotes>Added support for additional fields to create site user</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/VisualVault/VisualVault.Net.RestClient</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <PackageLicenseExpression></PackageLicenseExpression>
-    <FileVersion>5.2.5.0</FileVersion>
+    <FileVersion>5.2.6.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VVRestApi/VVRestApi/Vault/Sites/Site.cs
+++ b/VVRestApi/VVRestApi/Vault/Sites/Site.cs
@@ -12,6 +12,7 @@ using VVRestApi.Vault.Users;
 namespace VVRestApi.Vault.Sites
 {
     using System;
+    using System.Collections.Generic;
     using System.Dynamic;
     using Newtonsoft.Json;
     using VVRestApi.Common;
@@ -99,8 +100,9 @@ namespace VVRestApi.Vault.Sites
         /// <param name="emailAddress"></param>
         /// <param name="passwordExpireDate">If null, the password will never expire</param>
         /// <param name="getPasswordResetToken"></param>
+        /// <param name="additionalFields">Additional key value pairs to define user</param>
         /// <returns></returns>
-        public User CreateUser(string username, string password, string firstName, string middleInitial, string lastName, string emailAddress, DateTime? passwordExpireDate = null, bool getPasswordResetToken = false)
+        public User CreateUser(string username, string password, string firstName, string middleInitial, string lastName, string emailAddress, DateTime? passwordExpireDate = null, bool getPasswordResetToken = false, Dictionary<string, object> additionalFields = null)
         {
             dynamic newUser = new ExpandoObject();
             if (passwordExpireDate.HasValue)
@@ -120,6 +122,16 @@ namespace VVRestApi.Vault.Sites
             newUser.lastName = lastName;
             newUser.emailAddress = emailAddress;
             newUser.getPasswordResetToken = getPasswordResetToken;
+
+            if (additionalFields != null)
+            {
+                var newUserDict = newUser as IDictionary<string, object>;
+
+                foreach (KeyValuePair<string, object> field in additionalFields)
+                {
+                    newUserDict.Add(field.Key, field.Value);
+                }
+            }
 
             return HttpHelper.Post<User>(GlobalConfiguration.Routes.SitesIdAction, string.Empty, GetUrlParts(), this.ClientSecrets, this.ApiTokens, newUser, this.Id, "users");
         }

--- a/VVRestApi/VVRestApi/Vault/Users/UsersManager.cs
+++ b/VVRestApi/VVRestApi/Vault/Users/UsersManager.cs
@@ -34,7 +34,7 @@ namespace VVRestApi.Vault.Users
         /// <param name="passwordExpiresDate"></param>
         /// <param name="getPasswordResetToken"></param>
         /// <returns></returns>
-        public User CreateUser(Guid siteId, string userId, string firstName, string middleInitial, string lastName, string emailAddress, string password, bool passwordNeverExpires, DateTime passwordExpiresDate, bool getPasswordResetToken = false)
+        public User CreateUser(Guid siteId, string userId, string firstName, string middleInitial, string lastName, string emailAddress, string password, bool passwordNeverExpires, DateTime passwordExpiresDate, bool getPasswordResetToken = false, Dictionary<string, object> additionalFields = null)
         {
             dynamic postData = new ExpandoObject();
             postData.siteId = siteId;
@@ -47,6 +47,16 @@ namespace VVRestApi.Vault.Users
             postData.passwordNeverExpires = passwordNeverExpires;
             postData.passwordExpires = passwordExpiresDate.ToString("s");
             postData.getPasswordResetToken = getPasswordResetToken;
+
+            if (additionalFields != null)
+            {
+                var postDataDict = postData as IDictionary<string, object>;
+
+                foreach (KeyValuePair<string, object> field in additionalFields)
+                {
+                    postDataDict.Add(field.Key, field.Value);
+                }
+            }
 
             return HttpHelper.Post<User>(GlobalConfiguration.Routes.Users, "", GetUrlParts(), this.ClientSecrets, this.ApiTokens, postData);
         }
@@ -66,7 +76,7 @@ namespace VVRestApi.Vault.Users
         /// <param name="passwordNeverExpires"></param>
         /// <param name="getPasswordResetToken"></param>
         /// <returns></returns>
-        public User CreateUser(Guid siteId, string userId, string firstName, string middleInitial, string lastName, string emailAddress, string password, bool mustChangePassword = false, bool sendEmail = true, bool passwordNeverExpires = true, bool getPasswordResetToken = false)
+        public User CreateUser(Guid siteId, string userId, string firstName, string middleInitial, string lastName, string emailAddress, string password, bool mustChangePassword = false, bool sendEmail = true, bool passwordNeverExpires = true, bool getPasswordResetToken = false, Dictionary<string, object> additionalFields = null)
         {
             dynamic postData = new ExpandoObject();
             postData.siteId = siteId;
@@ -80,6 +90,16 @@ namespace VVRestApi.Vault.Users
             postData.sendEmail = sendEmail.ToString();
             postData.passwordNeverExpires = passwordNeverExpires;
             postData.getPasswordResetToken = getPasswordResetToken;
+
+            if (additionalFields != null)
+            {
+                var postDataDict = postData as IDictionary<string, object>;
+
+                foreach (KeyValuePair<string, object> field in additionalFields)
+                {
+                    postDataDict.Add(field.Key, field.Value);
+                }
+            }
 
             return HttpHelper.Post<User>(GlobalConfiguration.Routes.Users, "", GetUrlParts(), this.ClientSecrets, this.ApiTokens, postData);
         }
@@ -100,7 +120,7 @@ namespace VVRestApi.Vault.Users
         /// <param name="passwordNeverExpires"></param>
         /// <param name="getPasswordResetToken"></param>
         /// <returns></returns>
-        public User CreateUser(Guid siteId, string userId, string firstName, string middleInitial, string lastName, string emailAddress, string password, bool mustChangePassword, bool sendEmail, DateTime passwordExpiresDate, bool passwordNeverExpires, bool getPasswordResetToken = false)
+        public User CreateUser(Guid siteId, string userId, string firstName, string middleInitial, string lastName, string emailAddress, string password, bool mustChangePassword, bool sendEmail, DateTime passwordExpiresDate, bool passwordNeverExpires, bool getPasswordResetToken = false, Dictionary<string, object> additionalFields = null)
         {
             dynamic postData = new ExpandoObject();
             postData.siteId = siteId;
@@ -115,6 +135,16 @@ namespace VVRestApi.Vault.Users
             //postData.passwordNeverExpires = passwordNeverExpires;
             postData.passwordExpires = passwordExpiresDate.ToString("s");
             postData.getPasswordResetToken = getPasswordResetToken;
+
+            if (additionalFields != null)
+            {
+                var postDataDict = postData as IDictionary<string, object>;
+
+                foreach (KeyValuePair<string, object> field in additionalFields)
+                {
+                    postDataDict.Add(field.Key, field.Value);
+                }
+            }
 
             return HttpHelper.Post<User>(GlobalConfiguration.Routes.Users, "", GetUrlParts(), this.ClientSecrets, this.ApiTokens, postData);
         }

--- a/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests/UserAndGroupTests.cs
+++ b/VVRestApi/VVRestApiTests.Core/Tests/RestApiTests/UserAndGroupTests.cs
@@ -50,6 +50,36 @@ namespace VVRestApiTests.Core.Tests.RestApiTests
         }
 
         [Test]
+        public void CreateSiteUser()
+        {
+            var vaultApi = new VaultApi(this);
+
+            Assert.IsNotNull(vaultApi);
+
+            string siteName = "Home";
+            var site = vaultApi.Sites.GetSite(siteName);
+
+            Assert.IsNotNull(site, $"Unable to find site named '{siteName}'.");
+
+            var userId = "secondperson.namesecondperson.name@companyxyz.com";
+            var firstName = "Bill";
+            var middleInitial = "";
+            var lastName = "Windows";
+            var emailAddress = "secondperson.name@companyxyz.com";
+            var password = "Sample12345";
+            //var passwordNeverExpires = true;
+            //var passwordExpiresDate = new DateTime(2024, 1, 1);
+            var additionalFields = new Dictionary<string, object> {
+                { "employeeid",         "Plaidsoft" },
+                { "employmentstatus",   "Contracted" }
+            };
+
+            var user = site.CreateUser(userId, password, firstName, middleInitial, lastName, emailAddress, additionalFields: additionalFields);
+
+            Assert.IsNotNull(user, "Failed to create site user.");
+        }
+
+        [Test]
         public void GetUsersTest()
         {
             VaultApi vaultApi = new VaultApi(this);


### PR DESCRIPTION
- Updated the `Site` class `CreateUser` method to allow for additional fields to provide in the request using the optional  `additionalFields` argument.
  - This allows for fields such as "employeeid" or "employmentstatus".
- Updated the `CreateUser` overload methods for `UsersManager` to allow setting multiple fields using the optional `additionalFields` argument.
  - Implemented exactly the same as the `Site.CreateUser` method mentioned above.
- Created `CreateSiteUser` test case for `UserAndGroupTests.cs`.