### PR TITLE
Fix crashes + errors needed for annotation migration

### DIFF
--- a/VVRestApi/VVRestApi/Common/Messaging/HttpHelper.cs
+++ b/VVRestApi/VVRestApi/Common/Messaging/HttpHelper.cs
@@ -414,8 +414,10 @@ namespace VVRestApi.Common.Messaging
             {
                 try
                 {
-                    JObject result = await taskwithresponse.Result.Content.ReadAsAsync<JObject>();
-                    resultData = ProcessResultData(result, url, HttpMethod.Post);
+                    if (taskwithresponse.Result.Content.Headers.ContentLength > 0) {
+                        JObject result = await taskwithresponse.Result.Content.ReadAsAsync<JObject>();
+                        resultData = ProcessResultData(result, url, HttpMethod.Post);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/VVRestApi/VVRestApi/Vault/DocumentViewer/DocumentViewerManager.cs
+++ b/VVRestApi/VVRestApi/Vault/DocumentViewer/DocumentViewerManager.cs
@@ -38,11 +38,11 @@ namespace VVRestApi.Vault.DocumentViewer
             return result.Value<int>("data");
         }
 
-        public byte[] GetAllDocumentAnnotations(Guid documentId)
+        public List<DocumentViewerAnnotation> GetAllDocumentAnnotations(Guid documentId)
         {
             var queryString = "";
             var result = HttpHelper.Get(GlobalConfiguration.Routes.DocumentViewerIdAnnotations, queryString, null, GetUrlParts(), this.ApiTokens, this.ClientSecrets, documentId);
-            return result.Value<byte[]>("data");
+            return result["data"].ToObject<List<DocumentViewerAnnotation>>();
         }
 
         //public byte[] GetlDocumentAnnotationsByLayer(Guid documentId, string layerName)
@@ -91,7 +91,7 @@ namespace VVRestApi.Vault.DocumentViewer
             postData.layerName = annotationLayerName;
             postData.annotations = annotations;
 
-            var result = HttpHelper.Post(GlobalConfiguration.Routes.DocumentViewerIdAnnotations, "", GetUrlParts(), this.ApiTokens, postData, documentId);
+            HttpHelper.Post(GlobalConfiguration.Routes.DocumentViewerIdAnnotations, "", GetUrlParts(), ApiTokens, ClientSecrets, postData, documentId);
         }
 
 


### PR DESCRIPTION
This PR fixes three crashes I encountered while fetching and updating annotations:

 - `Cannot cast Newtonsoft.Json.Linq.JArray to Newtonsoft.Json.Linq.JToken` caused by `.Value<byte[]>` in GetAllDocumentAnnotations.
 -  A StackOverflow crash caused by attempting to `ReadAsAsync<JObject>` on an empty response.
 - A RuntimeBinderException caused by the call to `HttpHelper.Post` missing the `ClientSecrets` argument. I'm assuming this was a runtime error because of the similar `HttpHelper.Post<T>` function?